### PR TITLE
Container switch statements (Version 0.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,7 +181,7 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wcore"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "lazy_static",
  "phf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,12 +36,6 @@ name = "libc"
 version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e74d72e0f9b65b5b4ca49a346af3976df0f9c61d550727f349ecd559f251a26c"
-
-[[package]]
-name = "memchr"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "phf"
@@ -157,23 +142,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
-
-[[package]]
 name = "siphasher"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,6 +185,5 @@ version = "0.2.1"
 dependencies = [
  "lazy_static",
  "phf",
- "regex",
  "substring",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,4 @@ license = "MIT"
 [dependencies]
 substring = "1.4.5"
 phf = { version = "0.10.1", features = ["macros"] }
-regex = "1.5.4"
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wcore"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["James Butcher <jamesbutcher167@gmail.com>"]
 repository = "https://github.com/Wlanguage/core"

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -13,11 +13,13 @@ impl WEval for State {
         for section in data {
             match section.container {
                 Some(container) => {
-                    let mut cases = vec![(vec![Token::Value(1.0)], section.default_case)];
+                    let mut cases = vec![];
 
                     if let Some(container_cases) = section.cases {
-                        cases.append(&mut container_cases)
+                        cases.append(&mut container_cases.clone())
                     }
+
+                    cases.push((vec![Token::Value(1.0)], section.default_case));
 
                     self.insert(container, cases);
                 }

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -58,7 +58,18 @@ impl WEval for State {
                 let result = self.eval(match func {
                     WFuncVariant::Function(func) => func(code_to_evaluate),
                     WFuncVariant::Container(x) => {
-                        self.apply(self.get(&x).unwrap(), &code_to_evaluate)
+                        let mut case: WTokens = vec![];
+
+                        for container_case in self.get(&x).unwrap() {
+                            let case_prefix = self.apply(&container_case.0, &code_to_evaluate);
+
+                            if case_prefix[0] != Token::Value(0.0) {
+                                case = container_case.1.clone();
+                                break;
+                            }
+                        }
+
+                        self.apply(&case, &code_to_evaluate)
                     }
                 });
 

--- a/src/evaluator.rs
+++ b/src/evaluator.rs
@@ -1,4 +1,4 @@
-use crate::models::{State, WCode, WFuncVariant, WTokens};
+use crate::models::{State, WCode, WFuncVariant, WTokens, Token};
 use crate::utils::{first_special_instance, outter_function, special_pairs, WFunc};
 
 pub trait WEval {
@@ -13,9 +13,15 @@ impl WEval for State {
         for section in data {
             match section.container {
                 Some(container) => {
-                    self.insert(container, section.code);
+                    let mut cases = vec![(vec![Token::Value(1.0)], section.default_case)];
+
+                    if let Some(container_cases) = section.cases {
+                        cases.append(&mut container_cases)
+                    }
+
+                    self.insert(container, cases);
                 }
-                None => result.push(self.eval(section.code)),
+                None => result.push(self.eval(section.default_case)),
             }
         }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -70,22 +70,27 @@ pub fn lexer(code: &str) -> Vec<WCode> {
     let mut section_buffer: String = "".to_string();
     let mut sectioned_code: Vec<String> = vec![];
 
-    for line in code.split('\n') {
+    for line in code.split('\n').filter(|&x| x.trim() != "") {
         let re_result: Vec<bool> = container_symbols.iter().map(|x| line.contains(x)).collect();
 
         if re_result[1] && section_buffer.len() == 0 {
             section_buffer.push_str(line);
         } else if re_result[2] && section_buffer.len() > 0 {
-            section_buffer.push_str(line);
+            section_buffer.push_str(format!("\n{}", line).as_str());
         } else {
             if section_buffer.len() > 0 {
+                section_buffer.push_str(format!("\n{}", line).as_str());
                 sectioned_code.push(section_buffer);
                 section_buffer = String::new();
+            } else {
+                sectioned_code.push(line.to_string());
             }
-            sectioned_code.push(line.to_string());
         }
     }
-    sectioned_code.push(section_buffer);
+
+    if section_buffer.len() > 0 {
+        sectioned_code.push(section_buffer);
+    }
 
     sectioned_code
         .iter()

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,5 +1,3 @@
-use std::borrow::Borrow;
-
 use crate::models::{FunctionParameter, Token, WCode, WTokens};
 use crate::stdlib::FUNCTIONS;
 use lazy_static::lazy_static;

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -91,23 +91,27 @@ pub fn lexer(code: &str) -> Vec<WCode> {
             sectioned_code.push(line.to_string());
         }
     }
+    sectioned_code.push(section_buffer);
 
-    code.split('\n')
+    sectioned_code
+        .iter()
         .filter(|&x| x.trim() != "" && x != "\n")
-        .map(|line| match RE.find(line) {
-            Some(pos) => {
-                let container = line[..pos.start()].to_string();
-                let code = line[pos.end()..].to_string();
+        .map(|block| match RE.iter().map(|x| x.find(block)).collect::<Vec<Option<regex::Match>>>().as_slice() {
+            &[Some(pos), None, None] => {
+                let container = block[..pos.start()].to_string();
+                let code = block[pos.end()..].to_string();
                 containers.push(container.clone());
 
                 WCode {
                     container: Some(container),
-                    code: annotate(&code, &containers),
+                    cases: None,
+                    default_case: annotate(&code, &containers),
                 }
             }
-            None => WCode {
+            _ => WCode {
                 container: None,
-                code: annotate(line, &containers),
+                cases: None,
+                default_case: annotate(line, &containers),
             },
         })
         .collect()

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -124,7 +124,7 @@ pub fn lexer(code: &str) -> Vec<WCode> {
                         .filter(|x| !RE[1].is_match(x))
                         .collect();
 
-                    let default = cases.pop();
+                    let default: String = cases.pop().unwrap();
 
                     let other_cases: Vec<(WTokens, WTokens)> = cases
                         .iter()
@@ -139,7 +139,7 @@ pub fn lexer(code: &str) -> Vec<WCode> {
                     WCode {
                         container: Some(container),
                         cases: Some(other_cases),
-                        default_case: annotate(&code, &containers),
+                        default_case: annotate(&default, &containers),
                     }
                 }
                 _ => WCode {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -65,10 +65,32 @@ fn annotate(code: &str, containers: &Vec<String>) -> WTokens {
 
 pub fn lexer(code: &str) -> Vec<WCode> {
     lazy_static! {
-        static ref RE: Regex = Regex::new(" <- ").unwrap();
+        static ref RE: Vec<Regex> = [" <- ", " <-|", " -> "]
+            .iter()
+            .map(|x| Regex::new(x).unwrap())
+            .collect();
     }
 
     let mut containers = vec![];
+
+    let mut section_buffer: String;
+    let mut sectioned_code: Vec<String>;
+
+    for line in code.split('\n') {
+        let re_result: Vec<bool> = RE.iter().map(|x| x.is_match(line)).collect();
+
+        if re_result[1] && section_buffer.len() == 0 {
+            section_buffer.push_str(line);
+        } else if re_result[2] && section_buffer.len() > 0 {
+            section_buffer.push_str(line);
+        } else {
+            if section_buffer.len() > 0 {
+                sectioned_code.push(section_buffer);
+                section_buffer = String::new();
+            }
+            sectioned_code.push(line.to_string());
+        }
+    }
 
     code.split('\n')
         .filter(|&x| x.trim() != "" && x != "\n")

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -124,7 +124,8 @@ pub fn lexer(code: &str) -> Vec<WCode> {
 
                     let mut cases: Vec<String> = block[match_begin.end..]
                         .split('\n')
-                        .map(String::from)
+                        .filter(|&x| x.trim() != "" && x != "\n")
+                        .map(|x| String::from(x.trim()))
                         .filter(|x| !x.contains(container_symbols[1]))
                         .collect();
 
@@ -134,7 +135,7 @@ pub fn lexer(code: &str) -> Vec<WCode> {
                         .iter()
                         .map(|x| {
                             let sep: Vec<WTokens> =
-                                x.split("->").map(|y| annotate(y, &containers)).collect();
+                                x.split(container_symbols[2]).map(|y| annotate(y, &containers)).collect();
 
                             (sep[0].clone(), sep[1].clone())
                         })

--- a/src/models.rs
+++ b/src/models.rs
@@ -22,7 +22,8 @@ pub enum FunctionParameter {
 #[derive(Debug, Clone)]
 pub struct WCode {
     pub container: Option<String>,
-    pub code: WTokens,
+    pub cases: Option<(WTokens, WTokens)>,
+    pub default_case: WTokens,
 }
 
 #[derive(Debug, Clone)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Token {
     Value(f64),
     Function(fn(WTokens) -> WTokens),
@@ -34,4 +34,4 @@ pub enum WFuncVariant {
 
 pub type WTokens = Vec<Token>;
 pub type WFunc = fn(WTokens) -> WTokens;
-pub type State = HashMap<String, WTokens>;
+pub type State = HashMap<String, Vec<(WTokens, WTokens)>>;

--- a/src/models.rs
+++ b/src/models.rs
@@ -22,7 +22,7 @@ pub enum FunctionParameter {
 #[derive(Debug, Clone)]
 pub struct WCode {
     pub container: Option<String>,
-    pub cases: Option<(WTokens, WTokens)>,
+    pub cases: Option<Vec<(WTokens, WTokens)>>,
     pub default_case: WTokens,
 }
 


### PR DESCRIPTION
Add switch statements to containers for example
```
x <-|
  $0 2 eq -> 4 OUTPUT
  $0 3 eq -> 5 OUTPUT
  1 OUTPUT

3 x
```